### PR TITLE
added metadata/layout.conf

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,0 +1,25 @@
+# This went live Wednesday, July 4, 2012 at 10:00 UTC
+# For more details, please see: http://archives.gentoo.org/gentoo-dev-announce/msg_00000.xml
+# and/or GLEP 59.
+manifest-hashes = SHA256 SHA512 WHIRLPOOL
+
+# Bug #470670 - gentoo's council says to deprecate
+# EAPIs 1 and 2.
+eapis-deprecated = 1 2
+
+# Bug #337853 - gentoo's council says to enable
+# --echangelog by default for the "gentoo" repo
+update-changelog = true
+
+# Make egencache generate newer (more reliable)
+# md5-dict cache format (see bug #409445).
+# NOTE: list md5-dict first so clients prefer it
+# INFRA NOTE: Format 'pms' was removed on Aug 6 2012. (Announced prior as Aug 1
+# 2012 was the removal date)
+cache-formats = md5-dict
+
+# Support for implicit masters is deprecated, so we need to explicitly
+# specify that this repo does not dependent on any masters, in order
+# to distinguish it from repos that rely on the deprecated behavior.
+masters = gentoo
+


### PR DESCRIPTION
Added metadata/layout.conf file.
This file is needed for newest version of portage - without it any ebuild doesn't work, throws error like "couldn't find *.eclass file"
